### PR TITLE
Make sure statusd isn't nil before use in statusd_laptopstatus

### DIFF
--- a/statusd/statusd_laptopstatus.lua
+++ b/statusd/statusd_laptopstatus.lua
@@ -82,7 +82,9 @@ if not statusd_laptopstatus then
   }
 end
 
-statusd_laptopstatus=table.join(statusd.get_config("laptopstatus"), statusd_laptopstatus)
+if statusd ~= nil then
+    statusd_laptopstatus=table.join(statusd.get_config("laptopstatus"), statusd_laptopstatus)
+end
 
 --
 -- CODE 


### PR DESCRIPTION
It is obvious that the author of statusd_laptopstatus' intention was to make it executable as a standalone script. This is the only place where statusd is accessed without making sure it's set.
