### PR TITLE
statusd_laptopstatus: Remove use of table.getn()

### DIFF
--- a/statusd/statusd_laptopstatus.lua
+++ b/statusd/statusd_laptopstatus.lua
@@ -114,8 +114,8 @@ function average(array)
     for i,v in ipairs(array) do
         sum = sum + v
     end
-    if table.getn(array) ~= 0 then 
-       return sum / table.getn(array)
+    if #array ~= 0 then
+       return sum / #array
    else 
        return 0
    end


### PR DESCRIPTION
table.getn() was deprecated in Lua 5.1 and replaced with the unary length operator (#).

This causes problems when used with notion built against debian's lua-5.2; the meter doesn't update and prints errors about trying to access nil field.
